### PR TITLE
H-B-APT backmerge-from-upstream-for-heroku-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
 
 #### Aptfile
 
+    # you can list packages
     libpq-dev
+    # or include links to specific .deb files
     http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-precise-amd64.deb
+    # or add custom apt repos
     :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
 
 #### Gemfile

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Include a list of apt package names to be installed in a file named `Aptfile`
 
 #### Command-line
 
+To use the latest stable version:
+
+```
+heroku buildpacks:add --index 1 heroku-community/apt
+```
+
+To use the edge version (i.e. the code in this repo):
+
 ```
 heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
-for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:"); do
+for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e '^#' | grep -v -s -e "^:repo:"); do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb

--- a/bin/compile
+++ b/bin/compile
@@ -35,6 +35,13 @@ APT_SOURCELIST_DIR="$CACHE_DIR/apt/sources"   # place custom sources.list here
 
 APT_SOURCES="$APT_SOURCELIST_DIR/sources.list"
 
+APT_VERSION=$(apt-get -v | awk 'NR == 1{ print $2 }')
+
+case "$APT_VERSION" in
+  0* | 1.0*) APT_FORCE_YES="--force-yes";;
+  *)         APT_FORCE_YES="--allow-downgrades --allow-remove-essential --allow-change-held-packages";;
+esac
+
 if [ -f $APT_CACHE_DIR/Aptfile ] && cmp -s $BUILD_DIR/Aptfile $APT_CACHE_DIR/Aptfile ; then
   # Old Aptfile is the same as new
   topic "Reusing cache"
@@ -69,7 +76,7 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e '^#' | grep -v -s -e "^:
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y $APT_FORCE_YES -d install --reinstall $PACKAGE | indent
   fi
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,8 @@ else
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
+# Override the use of /etc/apt/sources.list (sourcelist) and /etc/apt/sources.list.d/* (sourceparts).
+APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=/dev/null"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -4,6 +4,7 @@
 
 testCompile() {
   cat > ${BUILD_DIR}/Aptfile <<EOF
+# Test comment
 s3cmd
 wget
 EOF


### PR DESCRIPTION
Basic backmerge from the upstream project.

I did this with all our buildpack deps, looking for `heroku-18` support items.

Interpreting this diff, I find no `heroku-18` changes. But I reckon taking an update is still good hygiene.